### PR TITLE
Resolve issues with swagger in shadow jar

### DIFF
--- a/pems-server/build.gradle
+++ b/pems-server/build.gradle
@@ -72,3 +72,7 @@ tasks.withType(JavaCompile) {
 tasks.withType(JavaExec) {
     systemProperty 'java.library.path', projectDir.toString() + '/lib/tinyb'
 }
+
+shadowJar {
+    mergeServiceFiles()
+}

--- a/pems-server/src/main/java/org/maroubra/pemsserver/jersey/JerseyApplication.java
+++ b/pems-server/src/main/java/org/maroubra/pemsserver/jersey/JerseyApplication.java
@@ -2,9 +2,14 @@ package org.maroubra.pemsserver.jersey;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.jaxrs.config.SwaggerContextService;
 import io.swagger.jaxrs.listing.ApiListingResource;
 import io.swagger.jaxrs.listing.SwaggerSerializers;
+import io.swagger.models.Contact;
+import io.swagger.models.Info;
+import io.swagger.models.License;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.maroubra.pemsserver.api.resources.HelloWorldResource;
 import org.maroubra.pemsserver.bindings.BluetoothBindings;
 import org.maroubra.pemsserver.bindings.MongoBindings;
 import org.maroubra.pemsserver.bindings.ObjectMapperFactory;
@@ -33,17 +38,25 @@ public class JerseyApplication extends ResourceConfig {
         register(new BluetoothBindings());
 
         // Swagger
+        Info info = new Info();
+        info.setTitle("PEMS Server API");
+        info.setVersion("1.0.0");
+        info.setLicense(new License().name("MIT"));
+        info.setContact(new Contact().url("https://github.com/ICTD-Maroubra/PEMS"));
+        info.setDescription("This following document describes the HTTP(S) API for interacting with the PEMS server.");
+
         BeanConfig beanConfig = new BeanConfig();
-        beanConfig.setTitle("PEMS Server API");
-        beanConfig.setVersion("1.0.0");
+        beanConfig.setInfo(info);
         beanConfig.setSchemes(new String[]{"http"});
         beanConfig.setHost(serverConfiguration.host + ":" + serverConfiguration.port);
         beanConfig.setBasePath("/");
-        beanConfig.setResourcePackage("org.maroubra.pemsserver.api.resources");
-        beanConfig.setServletConfig(null);
-        beanConfig.setScan(true);
+        beanConfig.setResourcePackage(HelloWorldResource.class.getPackage().getName());
+
+        new SwaggerContextService().withSwaggerConfig(beanConfig).withBasePath(beanConfig.getBasePath()).initConfig(beanConfig.getSwagger());
 
         register(ApiListingResource.class);
         register(SwaggerSerializers.class);
     }
+
+
 }


### PR DESCRIPTION
Resolves issue #13 

Instead of scanning at the point of creating the beanconfig, scan on first request for swagger definition. This way swagger will use the default JAX-RS scanner, after the servlet container has actually been defined.

Also ensured that service files are merged in shadow jar (for good measure)

A little convoluted the way I need create and apply the bean config using the info class... but it works. 